### PR TITLE
Fix case where ~/.ssh/id_rsa.pub is a softlink

### DIFF
--- a/scripts/xds-docker-create-container.sh
+++ b/scripts/xds-docker-create-container.sh
@@ -174,7 +174,7 @@ echo
 [ -f ~/.ssh/known_hosts ] && { ssh-keygen -R "[localhost]:$SSH_PORT" -f ~/.ssh/known_hosts || exit 1; }
 [ ! -f ~/.ssh/id_rsa.pub ] && { ssh-keygen -t rsa -f ~/.ssh/id_rsa -P "" > /dev/null || exit 1; }
 docker exec ${NAME} bash -c "mkdir -p /home/$DOCKER_USER/.ssh" || exit 1
-docker cp ~/.ssh/id_rsa.pub ${NAME}:/home/$DOCKER_USER/.ssh/authorized_keys || exit 1
+docker cp -L ~/.ssh/id_rsa.pub ${NAME}:/home/$DOCKER_USER/.ssh/authorized_keys || exit 1
 docker exec ${NAME} bash -c "chown $DOCKER_USER:$DOCKER_USER -R /home/$DOCKER_USER/.ssh ;chmod 0700 /home/$DOCKER_USER/.ssh; chmod 0600 /home/$DOCKER_USER/.ssh/*" || exit 1
 ssh -n -o StrictHostKeyChecking=no -p $SSH_PORT $DOCKER_USER@localhost exit || exit 1
 


### PR DESCRIPTION
Some users may have the default id_rsa/id_rsa.pub be a softlink to one
of a set of rsa keys. In this case, the cp would result in a dangling
softlink in the container and the startup fails. Adding a -L to the cp
command results in copying whatever the softlink points to into the
container, which seems like the desired behaviour.

Signed-off-by: brian avery <brian.avery@intel.com>